### PR TITLE
issue: Task Action Button Styling

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -78,7 +78,7 @@ if ($role->hasPerm(Task::PERM_DELETE)) {
             'delete' => array(
                 'href' => sprintf('#tasks/%d/delete', $task->getId()),
                 'icon' => 'icon-trash',
-                'class' => 'red button',
+                'class' => 'danger',
                 'label' => __('Delete'),
                 'redirect' => 'tasks.php'
             ));


### PR DESCRIPTION
This addresses an issue where the Delete Task Action Button had the wrong
classes which gave it the wrong styling. This corrects the class to make
the Delete button look like the other buttons and still have the red
background on hover.