### PR TITLE
xss: Prevent scp/index.php XSS

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -253,7 +253,7 @@ elseif ($_SESSION[$queue_sort_key][0] == 'relevance') {
 }
 
 if (isset($_GET['sort'])) {
-    $_SESSION[$queue_sort_key] = array($_GET['sort'], $_GET['dir']);
+    $_SESSION[$queue_sort_key] = array(Format::sanitize($_GET['sort']), Format::sanitize($_GET['dir']));
 }
 elseif (!isset($_SESSION[$queue_sort_key])) {
     $_SESSION[$queue_sort_key] = array($queue_sort_options[0], 0);


### PR DESCRIPTION
This addresses a vulnerability where an Agent can perform XSS on the
ticket queue via the REQUEST params. This sanitizes the params to ensure
any XSS code is not executed in the browser.