### PR TITLE
oops: Prevent Account Takeover

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -19,6 +19,12 @@
 require 'secure.inc.php';
 
 require_once 'class.user.php';
+
+// Check if User is Guest. If so, redirect them back to ticket page to
+// prevent Account Takeover.
+if ($thisclient->isGuest())
+    Http::redirect('tickets.php');
+
 $user = User::lookup($thisclient->getId());
 
 if ($user && $_POST) {


### PR DESCRIPTION
This addresses an issue where someone can “takeover” an account with only
a User’s email and a User’s previous ticket number. Once they get access
to a User’s ticket they can go to the Ticket Owner’s profile and change
the email to whatever they’d like. This adds a check on the profile to see
if the User is a Guest User. If they are a Guest then it kicks them back
to the ticket view. If they are the actual User it will let them view the
profile.