### PR TITLE
format: Fix Vimeo iFrames

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -321,7 +321,7 @@ class Format {
             'hook_tag' => function($e, $a=0) { return Format::__html_cleanup($e, $a); },
             'elements' => '*+iframe',
             'spec' =>
-            'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo)\.com/`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : ''),
+            'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo|player.vimeo)\.com/`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : ''),
         );
 
         return Format::html($html, $config);


### PR DESCRIPTION
This addresses an issue where some Vimeo videos are not being sent in
Agent’s responses. This adds `player.vimeo` to the sanitize method’s
iframe section so that the iframe tag is not stripped.